### PR TITLE
Added functionality to export formatting

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -847,7 +847,7 @@ namespace KeySAV2
                     ESV = "[" + ESV + "]";
                 }
             }
-            string result = String.Format(format, box, slot, species, gender, nature, ability, hp, atk, def, spa, spd, spe, hptype, ESV, TSV, nickname, otname, ball, TID, SID);
+            string result = String.Format(format, box, slot, species, gender, nature, ability, hp, atk, def, spa, spd, spe, hptype, ESV, TSV, nickname, otname, ball, TID, SID, ev_hp, ev_at, ev_de, ev_sa, ev_sd, ev_se, move1, move2, move3, move4, relearn1, relearn2, relearn3, relearn4, isshiny, isegg);
 
             if (ghost && CHK_MarkFirst.Checked) result = "~" + result;
             dumpedcounter++;
@@ -899,7 +899,7 @@ namespace KeySAV2
                 boxstart = Convert.ToInt16(CB_BoxStart.Text);
             }
 
-            string header = String.Format(RTB_OPTIONS.Text, "Box", "Slot", "Species", "Gender", "Nature", "Ability", "HP", "ATK", "DEF", "SPA", "SPD", "SPE", "HiddenPower", "ESV", "TSV", "Nick", "OT", "Ball", "TID", "SID");
+            string header = String.Format(RTB_OPTIONS.Text, "Box", "Slot", "Species", "Gender", "Nature", "Ability", "HP", "ATK", "DEF", "SPA", "SPD", "SPE", "HiddenPower", "ESV", "TSV", "Nick", "OT", "Ball", "TID", "SID", "HP EV", "ATK EV", "DEF EV", "SPA EV", "SPD EV", "SPE EV", "Move 1", "Move 2", "Move 3", "Move 4", "Relearn 1", "Relearn 2", "Relearn 3", "Relearn 4", "Shiny", "Egg");
             if (CB_ExportStyle.SelectedIndex == 1 || CB_ExportStyle.SelectedIndex == 2 || (CB_ExportStyle.SelectedIndex != 0 && CB_ExportStyle.SelectedIndex < 6 && CHK_R_Table.Checked))
             {
                 int args = Regex.Split(RTB_OPTIONS.Text, "{").Length;
@@ -1068,7 +1068,7 @@ namespace KeySAV2
                     ESV = "[" + ESV + "]";
                 }
             }
-            string result = String.Format(format, box, slot, species, gender, nature, ability, hp, atk, def, spa, spd, spe, hptype, ESV, TSV, nickname, otname, ball, TID, SID);
+            string result = String.Format(format, box, slot, species, gender, nature, ability, hp, atk, def, spa, spd, spe, hptype, ESV, TSV, nickname, otname, ball, TID, SID, ev_hp, ev_at, ev_de, ev_sa, ev_sd, ev_se, move1, move2, move3, move4, relearn1, relearn2, relearn3, relearn4, isshiny, isegg);
 
             RTB_VID.AppendText(result + "\r\n");
         } // BV
@@ -1089,9 +1089,9 @@ namespace KeySAV2
             {
                 offset = 0x5438;
                 keyoff = 0x800;
-            } 
-            
-            string header = String.Format(RTB_OPTIONS.Text, "~", "Slot", "Species", "Gender", "Nature", "Ability", "HP", "ATK", "DEF", "SPA", "SPD", "SPE", "HiddenPower", "ESV", "TSV", "Nick", "OT", "Ball", "TID", "SID");
+            }
+
+            string header = String.Format(RTB_OPTIONS.Text, "Box", "Slot", "Species", "Gender", "Nature", "Ability", "HP", "ATK", "DEF", "SPA", "SPD", "SPE", "HiddenPower", "ESV", "TSV", "Nick", "OT", "Ball", "TID", "SID", "HP EV", "ATK EV", "DEF EV", "SPA EV", "SPD EV", "SPE EV", "Move 1", "Move 2", "Move 3", "Move 4", "Relearn 1", "Relearn 2", "Relearn 3", "Relearn 4", "Shiny", "Egg");
 
             // Add header if reddit
             if (CB_ExportStyle.SelectedIndex == 1 || CB_ExportStyle.SelectedIndex == 2 || ((CB_ExportStyle.SelectedIndex != 0 && CB_ExportStyle.SelectedIndex < 6) && CHK_R_Table.Checked))
@@ -1840,6 +1840,12 @@ namespace KeySAV2
                 +"{27} - Move 2\r\n"
                 +"{28} - Move 3\r\n"
                 +"{29} - Move 4\r\n"
+                +"{30} - Relearn 1\r\n"
+                +"{31} - Relearn 2\r\n"
+                +"{32} - Relearn 3\r\n"
+                +"{33} - Relearn 4\r\n"
+                +"{34} - Is Shiny\r\n"
+                +"{35} - Is Egg\r\n"
                 ,"Help"
                 );
         }


### PR DESCRIPTION
Fix allows use of all 34 formatting options in custom styles; including
"bonus" options (shiny, egg, etc).  Added descriptions of said
formatting options in the help menu.
